### PR TITLE
Modify: read version from package.json

### DIFF
--- a/src/devreplayCli.ts
+++ b/src/devreplayCli.ts
@@ -15,14 +15,16 @@ import { fix, lintWithOutput } from './core/lint';
 const cli = {
     execute() {
         const program = new Command();
+        const {version} = require('.././package.json');
+
         program
-            .version('1.9.24')
+            .version(version)
             .description('A linter that replay your coding style')
             .option('--fix', 'Fix the file')
             // .option('--init', 'Make rules from recent git changes')
             .helpOption(true)
             .parse(process.argv);
-        
+
         const args = program.args;
         const argv = program.opts() ;
 


### PR DESCRIPTION
Hi🤚
## What problem did you solve?
The problem that`devreplay --version` was  9.24
I guess the command version hasn't been updated recently. And it's a problem that can happen again in the future.
If the package version and CLI version is same, I propose this way.

https://github.com/devreplay/devreplay/blob/56fc5991ef26167ddd6de411dd764a2451bb9147/src/devreplayCli.ts#L19

Please put the summary of this changes.
- read package version from `package.json` when use version in code

Please put the link if you have a related issue.
- none

Please choose the option for the pull request.

* [ ] Fix the default rules
* [ ] Fix the main function
* [ ] Fix the documentation
* [x] Other -> env

## (If you have)Screenshot
ASIS
![Screen Shot 2022-05-12 at 22 54 25](https://user-images.githubusercontent.com/49779936/168091583-12c60e20-0c67-4257-8c41-dd50494b936e.png)


TOBE
![Screen Shot 2022-05-12 at 22 53 33](https://user-images.githubusercontent.com/49779936/168091384-9c7c34ea-7f24-4634-9cf9-239b73ba3239.png)


